### PR TITLE
RunningPoolMonitor-MAX_RUNNING_SECONDS

### DIFF
--- a/fastgets/pool/running.py
+++ b/fastgets/pool/running.py
@@ -34,7 +34,7 @@ class RunningPool(object):
 class RunningPoolMonitor(object):
 
     CHECK_INTERVAL_SECONDS = 3
-    MAX_RUNNING_SECONDS = 60
+    MAX_RUNNING_SECONDS = 300
 
     def __init__(self, instance_id):
         self.instance_id = instance_id


### PR DESCRIPTION
将每个task最大运行实际设置为300秒，超过300秒放回任务队列